### PR TITLE
Add version update workflow

### DIFF
--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -1,0 +1,62 @@
+name: Update package version for release & hotfix branches
+
+on:
+  workflow_call:
+    secrets:
+      caller_github_token:
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - name: update package version
+        id: vars
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          PACKAGE_VERSION="${GITHUB_REF##*/}"
+          echo ::set-output name=branch::${BRANCH_NAME}
+          if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]
+          then
+            if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+$ ]]
+            then
+              PACKAGE_VERSION="${PACKAGE_VERSION}.0"
+            fi
+            echo ::set-output name=version::${PACKAGE_VERSION}
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            if npm --no-git-tag-version version ${PACKAGE_VERSION} &> temp-npm-version.txt
+            then
+              echo ::set-output name=should_create_pr::1
+              git add package.json package-lock.json
+              git commit -m ${PACKAGE_VERSION}
+              git push -u origin HEAD:"dev/update-version-${PACKAGE_VERSION}"
+              exit 0
+            fi
+            echo ::set-output name=should_create_pr::0
+            if grep -q 'npm ERR! Version not changed' temp-npm-version.txt
+            then
+              echo "Package version is already in sync with branch name."
+              exit 0
+            fi
+            cat temp-npm-version.txt
+            exit 1
+          else
+            echo "Branch name ${BRANCH_NAME} does not have the correct format with package version."
+            exit 1
+          fi
+      - name: create version update pr
+        if: steps.vars.outputs.should_create_pr == 1
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "dev/update-version-${{ steps.vars.outputs.version }}"
+          destination_branch: "${{ steps.vars.outputs.branch }}"
+          pr_title: "Update Package Version to ${{ steps.vars.outputs.version }}"
+          pr_body: "*An automated PR which updates the version number in package.json and package-lock.json files*"
+          github_token: ${{ secrets.caller_github_token }}


### PR DESCRIPTION
Fix the workflow for making automated version update PRs and make it callable. Previously, the workflow never made a PR because the `tee` command had an exit code of 0, so it always thought the package version was in sync even if it wasn't. This workflow first checks the exit status of `npm version` before deciding whether or not to make a PR. Also, we don't want a tag to be automatically tied to the commit that's made for the version update, so the `--no-git-tag-version` flag was added and the package file changes are manually added and committed.

J=SLAP-2004, SLAP-1931
TEST=manual

Add this workflow to a test branch in Headless. Call it from the SDK and check that if the package version is outdated, an automated PR is made to update it. If the package version matches the branch version, see that no PR is made.