### PR TITLE
Update main sync workflow to create a merge branch

### DIFF
--- a/.github/workflows/sync_develop_and_main.yml
+++ b/.github/workflows/sync_develop_and_main.yml
@@ -19,8 +19,9 @@ jobs:
         id: vars
         run: |
           PACKAGE_VERSION="v$(cat ./package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')"
+          COMMIT_HASH="$(git rev-parse --short HEAD)"
           echo ::set-output name=tag::${PACKAGE_VERSION}
-          echo ::set-output name=merge_branch_name::"dev/merge-${PACKAGE_VERSION}-into-develop"
+          echo ::set-output name=merge_branch_name::"dev/merge-${PACKAGE_VERSION}-${COMMIT_HASH}-into-develop"
       - name: Create merge branch
         uses: peterjgrainger/action-create-branch@v2.0.1
         with:


### PR DESCRIPTION
Update the GH action which makes the PR from main to develop by creating a merge branch into develop instead of creating a PR directly from main/master.

The action will create a merge branch such as "dev/merge-v1.5.4-d8jd23k-into-develop" to merge into develop. This allows us to resolve any merge conflicts in that branch before merging into develop. In order for the merge branch to be based on master, this workflow must be called on a the main/master branch.

I included a commit hash in the branch title so that new commits to master will always create a new branch and PR.

J=SLAP-1966
TEST=manual

Use a forked copy of answers-core to call the workflow and see the new branch and PR