### PR TITLE
use repo scope token in 3rd party and update doc workflows

### DIFF
--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -10,6 +10,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: false
+      REPO_SCOPE_TOKEN:
+        required: false
 
 jobs:
   license-check:
@@ -21,6 +23,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install -g generate-license-file
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.REPO_SCOPE_TOKEN }}
       # Skip post-install scripts here, as a malicious
       # script could steal the NPM_TOKEN.
       - run: npm ci --ignore-scripts

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -10,7 +10,7 @@ on:
     secrets:
       NPM_TOKEN:
         required: false
-      REPO_SCOPE_TOKEN:
+      REPO_SCOPED_TOKEN:
         required: true
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
       - run: npm install -g generate-license-file
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.REPO_SCOPE_TOKEN }}
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
       # Skip post-install scripts here, as a malicious
       # script could steal the NPM_TOKEN.
       - run: npm ci --ignore-scripts

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -11,7 +11,7 @@ on:
       NPM_TOKEN:
         required: false
       REPO_SCOPE_TOKEN:
-        required: false
+        required: true
 
 jobs:
   license-check:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -7,12 +7,17 @@ on:
         required: false
         type: string
         default: npm run build
+    secrets:
+      REPO_SCOPE_TOKEN:
+        required: true
 
 jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.REPO_SCOPE_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -8,7 +8,7 @@ on:
         type: string
         default: npm run build
     secrets:
-      REPO_SCOPE_TOKEN:
+      REPO_SCOPED_TOKEN:
         required: true
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.REPO_SCOPE_TOKEN }}
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x


### PR DESCRIPTION
This pr updates third_party_notices_check.yml and update_docs.yml to require a repo scoped token so any automated commits (in this case coming from the third party github actions EndBug/add-and-commit) will trigger a rerun of all the other github workflows, such as the unit and percy tests. Otherwise, all workflows are halted. From their [doc](https://github.com/EndBug/add-and-commit#the-commit-from-the-action-is-not-triggering-ci), this token is to be added to actions/checkout. This repo scoped token will be generated by slapshot-bot account.

Note: will also merge to v1 branch in this repo. and will update repos that have these two workflows after the merges

J=SLAP-2044
TEST=manual

In answers-core repo, added third_party_notices_check.yml and modified update_docs.yml to provide a repo scoped token. See that without it, the tests doesn't rerun. With the new token - provided by slapshot bot account, the tests rerun after an automated commit is added.
https://github.com/yext/answers-core/pull/155