### PR TITLE
pin generate license version to v1

### DIFF
--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g generate-license-file
+      - run: npm install -g generate-license-file@1
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.REPO_SCOPED_TOKEN }}


### PR DESCRIPTION
library generate-license-file recently publish a v2, which contains minor changes to the generated file compared to v1. Additionally, looks like it also doesn't support node v12 (failed in search-core github action test). This pr pinned the version to v1 so we don't get auto update to the file from github action using v2, which prevent us to use the `slap` publish command as there will be changes in the THIRD-PARTY-NOTICES file running the local v1 in our current repos.