### PR TITLE
Update WCAG github action to accept mapbox API key

### DIFF
--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -14,6 +14,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: false
+      MAPBOX_API_KEY:
+        required: false
 
 jobs:
   WCAG-test:
@@ -35,3 +37,5 @@ jobs:
       - run: npm rebuild
       - run: ${{ inputs.build_script }}
       - run: npm run wcag
+        env:
+          MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -36,6 +36,8 @@ jobs:
       # `npm rebuild` will run all those post-install scripts for us.
       - run: npm rebuild
       - run: ${{ inputs.build_script }}
+        env:
+          MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
       - run: npm run wcag
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -39,5 +39,3 @@ jobs:
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
       - run: npm run wcag
-        env:
-          MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}


### PR DESCRIPTION
When testing wcag in search-react-ui repo, the mapbox API key is required to use Mapbox GL in storybook. Updated the workflow to optionally accept a mapbox API key as an env variable for the build step.

J=none
TEST=manual

tested in this PR: https://github.com/yext/search-ui-react/pull/331, where wcag error `An API access token is required to use Mapbox GL.` is no longer present after using the workflow from this branch.