### PR TITLE
Pass mapbox API key to test and coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: false
+      MAPBOX_API_KEY:
+        required: false
       caller_github_token:
         required: true
 
@@ -40,6 +42,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm rebuild
       - run: ${{ inputs.test_script }}
+        env:
+          MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
       - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
         id: parse-coverage
       - run: echo base coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
@@ -59,6 +63,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm rebuild
       - run: ${{ inputs.test_script }}
+        env:
+          MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
       - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
         id: parse-coverage
       - run: echo current coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,7 +25,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: false
-
+      MAPBOX_API_KEY:
+        required: false
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -54,3 +55,5 @@ jobs:
       - run: npm rebuild
       - run: ${{ inputs.build_script }}
       - run: ${{ inputs.test_script }}
+        env:
+          MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}


### PR DESCRIPTION
the issue with coverage test in search-ui-react repo stems from errors caused within the visual tests from storybook due to missing mapbox API key. This is also an issue when running test workflow where mapbox related visual tests failed due to missing mapbox API key (it also failed silently / test github action "passed" when there are tests failed -- that will be address in this [item](https://yexttest.atlassian.net/browse/SLAP-2459)).

J=SLAP-2467
TEST=auto

- see that coverage GH now works as expected in this search-ui-react PR: https://github.com/yext/search-ui-react/pull/339
- see that mapbox errors in test GH in search-ui-react no longer appear in this PR: https://github.com/yext/search-ui-react/pull/339