### PR TITLE
Remove Node 12 testing and deprecation warnings

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ on:
       node_matrix:
         required: false
         type: string
-        default: '["12.x", "14.x", "16.x"]'
+        default: '["14.x", "16.x"]'
     secrets:
       NPM_TOKEN:
         required: false

--- a/.github/workflows/sync_develop_and_main.yml
+++ b/.github/workflows/sync_develop_and_main.yml
@@ -23,7 +23,7 @@ jobs:
           echo tag=${PACKAGE_VERSION} >> $GITHUB_OUTPUT
           echo merge_branch_name="dev/merge-${PACKAGE_VERSION}-${COMMIT_HASH}-into-develop" >> $GITHUB_OUTPUT
       - name: Create merge branch
-        uses: peterjgrainger/action-create-branch@v2.0.1
+        uses: peterjgrainger/action-create-branch@v2.4.0
         with:
           branch: ${{ steps.vars.outputs.merge_branch_name }}
         env:


### PR DESCRIPTION
Stop running the `run-tests` workflow on Node 12 by default now that it is deprecated. Also, update the `peterjgrainger/action-create-branch` GH action that is used in the `sync_develop_and_main` workflow to remove the Node 12 deprecation [warning](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) it was producing.

Note: There is still one Node 12 warning left, which comes from `coverallsapp/github-action` in the `coverage` workflow. There is already an [issue](https://github.com/coverallsapp/github-action/issues/132) made on that repo and it seems to be waiting on the merging of [this PR](https://github.com/coverallsapp/github-action/pull/117). Since we are pointing to their `master` branch, once the PR is merged, we will get the fix without any action needed on our part.

J=SLAP-2468
TEST=manual

Test both workflow changes on a forked repo. See that tests are only run on Node 14 and 16 by default and that there are no more Node 12 deprecation warnings from the syncing workflow.