### PR TITLE
Add sync_default_branch workflow

### DIFF
--- a/.github/workflows/sync_default_branch.yml
+++ b/.github/workflows/sync_default_branch.yml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Sync ${{ github.event.repository.default_branch }} with ${{ inputs.target_branch }}
         uses: devmasx/merge-branch@v1.4.0
-          with:
-            type: now
-            from_branch: ${{ github.event.repository.default_branch }}
-            target_branch: ${{ inputs.target_branch }}
-            github_token: ${{ secrets.caller_github_token }}
+        with:
+          type: now
+          from_branch: ${{ github.event.repository.default_branch }}
+          target_branch: ${{ inputs.target_branch }}
+          github_token: ${{ secrets.caller_github_token }}

--- a/.github/workflows/sync_default_branch.yml
+++ b/.github/workflows/sync_default_branch.yml
@@ -1,0 +1,26 @@
+name: Sync Default Branch with Target Branch
+
+on:
+  workflow_call:
+    inputs:
+      target_branch:
+        required: false
+        type: string
+        default: storybook-site
+    secrets:
+      caller_github_token:
+        required: true
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Sync branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: devmasx/merge-branch@v1.4.0
+        with:
+          type: now
+          from_branch: ${{ github.event.repository.default_branch }}
+          target_branch: ${{ inputs.target_branch }}
+          github_token: ${{ secrets.caller_github_token }}

--- a/.github/workflows/sync_default_branch.yml
+++ b/.github/workflows/sync_default_branch.yml
@@ -18,9 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: devmasx/merge-branch@v1.4.0
-        with:
-          type: now
-          from_branch: ${{ github.event.repository.default_branch }}
-          target_branch: ${{ inputs.target_branch }}
-          github_token: ${{ secrets.caller_github_token }}
+      - name: Sync ${{ github.event.repository.default_branch }} with ${{ inputs.target_branch }}
+        uses: devmasx/merge-branch@v1.4.0
+          with:
+            type: now
+            from_branch: ${{ github.event.repository.default_branch }}
+            target_branch: ${{ inputs.target_branch }}
+            github_token: ${{ secrets.caller_github_token }}

--- a/.github/workflows/sync_default_branch.yml
+++ b/.github/workflows/sync_default_branch.yml
@@ -4,9 +4,8 @@ on:
   workflow_call:
     inputs:
       target_branch:
-        required: false
+        required: true
         type: string
-        default: storybook-site
     secrets:
       caller_github_token:
         required: true


### PR DESCRIPTION
Add a workflow for syncing a repo's default branch with a specified target branch (required input).

J=SLAP-2507
TEST=manual

Test on a forked repo and see that calling this workflow successfully syncs the default branch with a target branch.