### PR TITLE
Remove node 14 from automated tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ on:
       node_matrix:
         required: false
         type: string
-        default: '["14.x", "16.x"]'
+        default: '["16.x"]'
     secrets:
       NPM_TOKEN:
         required: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/


### PR DESCRIPTION
Remove node 14 from automated tests

Node 14 is no longer maintained, so we should remove it from our automated tests. tsup causes issues during an npm install when using node 14 which is causing issues in the repos where we are introducing it. We should also consider introducing node 18 or 20 to the test matrix, but that is out of scope.

J=BACK-2545
TEST=manual

I confirmed that tsup is compatible with node 16, but not with 14