### PR TITLE
Node 20 upgrade for get-coverage-percent

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
       - run: ${{ inputs.test_script }}
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
-      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
+      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@@node-20-upgrade
         id: parse-coverage
       - run: echo base coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
   current-coverage:
@@ -65,7 +65,7 @@ jobs:
       - run: ${{ inputs.test_script }}
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
-      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
+      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@@node-20-upgrade
         id: parse-coverage
       - run: echo current coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
       - name: Upload lcov build artifact

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
       - run: ${{ inputs.test_script }}
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
-      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@node-20-upgrade
+      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
         id: parse-coverage
       - run: echo base coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
   current-coverage:
@@ -65,7 +65,7 @@ jobs:
       - run: ${{ inputs.test_script }}
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
-      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@node-20-upgrade
+      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
         id: parse-coverage
       - run: echo current coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
       - name: Upload lcov build artifact

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
       - run: ${{ inputs.test_script }}
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
-      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@@node-20-upgrade
+      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@node-20-upgrade
         id: parse-coverage
       - run: echo base coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
   current-coverage:
@@ -65,7 +65,7 @@ jobs:
       - run: ${{ inputs.test_script }}
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
-      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@@node-20-upgrade
+      - uses: yext/slapshot-reusable-workflows/get-coverage-percent@node-20-upgrade
         id: parse-coverage
       - run: echo current coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
       - name: Upload lcov build artifact

--- a/get-coverage-percent/action.yml
+++ b/get-coverage-percent/action.yml
@@ -9,5 +9,5 @@ outputs:
   coverage-percent:
     description: the coverage percent
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Update the node version of the get-coverage-percent action to 20.

J=WAT-3812
TEST=manual

Made a new branch on a repo which used the coverage workflow which uses this action, and temporarily updated the workflow and the branch on the other repo to reference this branch. [Triggered the workflow](https://github.com/yext/answers-search-ui/actions/runs/8395734213) and saw the warning about using a deprecated version of node was no longer present.