### PR TITLE
Updated coverage workflow to satisfy node20 requirements

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -96,4 +96,5 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
+          file: coverage/lcov.info
           github-token: ${{ secrets.caller_github_token }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,11 +29,11 @@ jobs:
     outputs:
       coverage-percent: ${{ steps.parse-coverage.outputs.coverage-percent }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.comparison_branch }}
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
@@ -52,9 +52,9 @@ jobs:
     outputs:
       coverage-percent: ${{ steps.parse-coverage.outputs.coverage-percent }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
@@ -69,7 +69,7 @@ jobs:
         id: parse-coverage
       - run: echo current coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%
       - name: Upload lcov build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage/
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [base-coverage, current-coverage]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check if percent is too low
         run: |
           percentIsTooLow=$(echo ${{ needs.base-coverage.outputs.coverage-percent }} ${{ needs.current-coverage.outputs.coverage-percent }} |
@@ -89,11 +89,11 @@ jobs:
             exit 1
           fi
       - name: Download the current coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
           path: coverage/
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.caller_github_token }}


### PR DESCRIPTION
Updated .github/workflows/coverage.yml to use new workflow action versions so as to get rid of previous node16 deprecation warnings after workflow builds. 

Some things to note:

1. We bumped `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact` to their respective versions 4. 

2. Updated `coverallsapp/github-action` to use version 2, which now requires us to specify a `coverage/lcov.info` in the build action because according to Coveralls' [release notes here](https://github.com/coverallsapp/github-action/releases/tag/v2), v2 automatically tries to find all supported coverage files and then combine their data. `coverage/lcov.info` was the previous default file path for the coverage file used by [node-coveralls](https://github.com/nickmerwin/node-coveralls?tab=readme-ov-file) and we're now manually specifying the path so there's no behavior change from from the above update.

3. Because we're updating the upload action to v4, any repo that downloads the coverage (which seems to just be `search-ui-react`) will need to upgrade their download action to v4


[J=WAT-3813](https://yexttest.atlassian.net/jira/software/c/projects/WAT/boards/1991?assignee=5b0e9603fa615349cb0167c3&selectedIssue=WAT-3813)

Tested by pointing some libraries that depend on this workflow to this workflow branch and seeing that deprecation warnings have disappeared. 

