### PR TITLE
Remove node 16 deprecation warnings from most workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,5 @@ jobs:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: semgrep ci

--- a/.github/workflows/percy_snapshots.yml
+++ b/.github/workflows/percy_snapshots.yml
@@ -33,11 +33,11 @@ jobs:
   percy_snapshots:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.fetch_depth }}
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - run: npm ci

--- a/.github/workflows/run-linting.yml
+++ b/.github/workflows/run-linting.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
       - run: npm ci
       - run: ${{ inputs.lint_script }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,9 +40,9 @@ jobs:
         node-version: ${{ fromJSON(inputs.node_matrix) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/sync_default_branch.yml
+++ b/.github/workflows/sync_default_branch.yml
@@ -16,7 +16,7 @@ jobs:
     name: Sync branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Sync ${{ github.event.repository.default_branch }} with ${{ inputs.target_branch }}
         uses: devmasx/merge-branch@v1.4.0
         with:

--- a/.github/workflows/sync_develop_and_main.yml
+++ b/.github/workflows/sync_develop_and_main.yml
@@ -14,7 +14,7 @@ jobs:
   create_pull_request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Extract version and merge branch name
         id: vars
         run: |
@@ -23,7 +23,7 @@ jobs:
           echo tag=${PACKAGE_VERSION} >> $GITHUB_OUTPUT
           echo merge_branch_name="dev/merge-${PACKAGE_VERSION}-${COMMIT_HASH}-into-develop" >> $GITHUB_OUTPUT
       - name: Create merge branch
-        uses: peterjgrainger/action-create-branch@v2.4.0
+        uses: peterjgrainger/action-create-branch@v3.0.0
         with:
           branch: ${{ steps.vars.outputs.merge_branch_name }}
         env:

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -17,12 +17,12 @@ jobs:
   license-check:
     runs-on: ${{ inputs.environment }}
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
       - run: npm install -g generate-license-file@1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.REPO_SCOPED_TOKEN }}

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -15,11 +15,11 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.REPO_SCOPED_TOKEN }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - run: npm ci

--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -14,8 +14,8 @@ jobs:
   update-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: update package version
         id: vars
         run: |

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -21,10 +21,10 @@ jobs:
   WCAG-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.fetch_depth }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Update `main.yml`, `percy_snapshots.yml`, `run-linting.yml`, `run_tests.yml`, `sync_default_branch.yml`, `sync_develop_and_main.yml`, `third_party_notices_check.yml`, `.update_docs.yml`, `version_update.yml`, and `wcag_test.yml` to remove Node 16 deprecation warnings.

J=WAT-3814
TEST=manual

For `main.yml`, test the check on this PR, for `percy_snapshots.yml`, test in `answers-search-ui`, and for the other workflows, test in a fork of `search-ui-react` and see that the workflows no longer produce warnings.