### PR TITLE
Remove run shell injection vulnerability (pt2)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,9 +45,10 @@ jobs:
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
           TEST_SCRIPT: ${{ inputs.test_script }}
+          COVERAGE_PERCENT: ${{ steps.parse-coverage.outputs.coverage-percent }}
       - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
         id: parse-coverage
-      - run: echo "base coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%"
+      - run: echo base coverage is "$COVERAGE_PERCENT"%
   current-coverage:
     runs-on: ubuntu-latest
     outputs:
@@ -67,9 +68,10 @@ jobs:
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
           TEST_SCRIPT: ${{ inputs.test_script }}
+          COVERAGE_PERCENT: ${{ steps.parse-coverage.outputs.coverage-percent }}
       - uses: yext/slapshot-reusable-workflows/get-coverage-percent@v1
         id: parse-coverage
-      - run: echo "current coverage is ${{ steps.parse-coverage.outputs.coverage-percent }}%"
+      - run: echo current coverage is "$COVERAGE_PERCENT"%
       - name: Upload lcov build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/percy_snapshots.yml
+++ b/.github/workflows/percy_snapshots.yml
@@ -57,8 +57,9 @@ jobs:
         env:
           SNAPSHOTS_SCRIPT_PATH: ${{ inputs.snapshots_script_path }}
           PERCY_SCRIPT: ${{ inputs.percy_script }}
+          MERGED_PERCY_SCRIPT: ${{ steps.vars.outputs.merged_percy_script }}
       - name: Percy Snapshots
-        run: "${{ steps.vars.outputs.merged_percy_script }}"
+        run: "$MERGED_PERCY_SCRIPT"
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ inputs.PERCY_PARALLEL_NONCE }}


### PR DESCRIPTION
Prevents attackers from injecting their own code into the github actions runner using variable interpolation to steal screts and code. We now use an intermediate environment variable to store input data (p2).

J=VULN-39623,VULN-39624,VULN-39625