### PR TITLE
feat: add configuration options to third-party-notices workflow

### DIFF
--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: --input package.json --output ./THIRD-PARTY-NOTICES --overwrite
+      generate_license_version:
+        required: false
+        type: string
+        default: '1'
     secrets:
       NPM_TOKEN:
         required: false
@@ -25,7 +29,7 @@ jobs:
         with:
           node-version: 18.x
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g generate-license-file@1
+      - run: npm install -g generate-license-file@${{ inputs.generate_license_version }}
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -7,6 +7,10 @@ on:
         required: false
         type: string
         default: ubuntu-latest
+      generate_license_args:
+        required: false
+        type: string
+        default: --input package.json --output ./THIRD-PARTY-NOTICES --overwrite
     secrets:
       NPM_TOKEN:
         required: false
@@ -33,7 +37,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # `npm rebuild` will run all those post-install scripts for us.
       - run: npm rebuild
-      - run: generate-license-file --input package.json --output ./THIRD-PARTY-NOTICES --overwrite
+      - run: generate-license-file ${{ inputs.generate_license_args }}
       - name: Update THIRD-PARTY-NOTICES
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
Makes the version and parameters configurable. This is to allow the upgrade in `search-ui-react` (which upgraded the license gen to v4) to work properly. 

Relevant changes: https://github.com/yext/search-ui-react/pull/584, https://github.com/yext/search-ui-react/pull/586

TEST=manual
Pointed to this branch in `search-ui-react` PR and saw the licenses use the override as expected