### PR TITLE
fix: string parsing typo in percy workflow

### DIFF
--- a/.github/workflows/percy_snapshots.yml
+++ b/.github/workflows/percy_snapshots.yml
@@ -49,9 +49,9 @@ jobs:
         id: vars
         run: |
           merged_percy_script='npx percy exec -- node "$SNAPSHOTS_SCRIPT_PATH"'
-          if [[ '"$PERCY_SCRIPT"' ]]
+          if [[ -n "${PERCY_SCRIPT:-}" ]]
           then
-            merged_percy_script='"$PERCY_SCRIPT"'
+            merged_percy_script="${PERCY_SCRIPT}"
           fi
           echo "merged_percy_script=${merged_percy_script}" >> $GITHUB_OUTPUT
         env:


### PR DESCRIPTION
The `if` check was always being evaluated to true because it was checking a string literal's truthy value