### PR TITLE
feat: upgrade to node 20

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,10 +32,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.comparison_branch }}
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci --ignore-scripts
         env:
@@ -57,10 +57,10 @@ jobs:
       coverage-percent: ${{ steps.parse-coverage.outputs.coverage-percent }}
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci --ignore-scripts
         env:

--- a/.github/workflows/percy_snapshots.yml
+++ b/.github/workflows/percy_snapshots.yml
@@ -36,10 +36,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.fetch_depth }}
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm ci
       - run: "$BUILD_SCRIPT"
         env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ on:
       node_matrix:
         required: false
         type: string
-        default: '["18.x"]'
+        default: '["20.x"]'
     secrets:
       NPM_TOKEN:
         required: false

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
       - run: npm install -g generate-license-file@${{ inputs.generate_license_version }}
       - uses: actions/checkout@v4

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.REPO_SCOPED_TOKEN }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm ci
       - run: "$BUILD_SCRIPT"
         env:

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: ${{ inputs.fetch_depth }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
       # Skip post-install scripts here, as a malicious
       # script could steal the NPM_TOKEN.


### PR DESCRIPTION
Similarly to
https://github.com/yext/slapshot-reusable-workflows/pull/54/changes upgrade to 20, as 18 is end-of-life.