### PR TITLE
fix: script variable expansion in percy snapshots

### DIFF
--- a/.github/workflows/percy_snapshots.yml
+++ b/.github/workflows/percy_snapshots.yml
@@ -41,26 +41,21 @@ jobs:
         with:
           node-version: 20.x
       - run: npm ci
-      - run: "$BUILD_SCRIPT"
+      - run: bash -c "$BUILD_SCRIPT"
         env:
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
           BUILD_SCRIPT: ${{ inputs.build_script }}
-      - name: Get Percy script
-        id: vars
+      - name: Percy Snapshots
         run: |
           merged_percy_script='npx percy exec -- node "$SNAPSHOTS_SCRIPT_PATH"'
           if [[ -n "${PERCY_SCRIPT:-}" ]]
           then
             merged_percy_script="${PERCY_SCRIPT}"
           fi
-          echo "merged_percy_script=${merged_percy_script}" >> $GITHUB_OUTPUT
-        env:
-          SNAPSHOTS_SCRIPT_PATH: ${{ inputs.snapshots_script_path }}
-          PERCY_SCRIPT: ${{ inputs.percy_script }}
-      - name: Percy Snapshots
-        run: "$MERGED_PERCY_SCRIPT"
+          bash -c "$merged_percy_script"
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ inputs.PERCY_PARALLEL_NONCE }}
           PERCY_PARALLEL_TOTAL: ${{ inputs.PERCY_PARALLEL_TOTAL }}
-          MERGED_PERCY_SCRIPT: ${{ steps.vars.outputs.merged_percy_script }}
+          SNAPSHOTS_SCRIPT_PATH: ${{ inputs.snapshots_script_path }}
+          PERCY_SCRIPT: ${{ inputs.percy_script }}


### PR DESCRIPTION
The workflow built `npx percy exec -- node "$SNAPSHOTS_SCRIPT_PATH"`, but then passed it through $GITHUB_OUTPUT and ran it as "$MERGED_PERCY_SCRIPT". That means the nested "$SNAPSHOTS_SCRIPT_PATH" was never evaluated as a shell variable. Node received the literal path "$SNAPSHOTS_SCRIPT_PATH", which produced a
```
Cannot find module 'path/to/"$SNAPSHOTS_SCRIPT_PATH"'
```
error. This PR patches the workflow to execute script inputs with `bash -c`, and to run the merged Percy command directly.